### PR TITLE
Vhost user gpu small fixes

### DIFF
--- a/contrib/vhost-user-gpu/main.c
+++ b/contrib/vhost-user-gpu/main.c
@@ -1089,7 +1089,7 @@ static GOptionEntry entries[] = {
       "PID path", "PATH" },
     { "fd", 'f', 0, G_OPTION_ARG_INT, &opt_fdnum,
       "Use inherited fd socket", "FDNUM" },
-    { "socket-path", 's', 0, G_OPTION_ARG_INT, &opt_socket_path,
+    { "socket-path", 's', 0, G_OPTION_ARG_FILENAME, &opt_socket_path,
       "Use UNIX socket path", "PATH" },
     { "render-node", 'r', 0, G_OPTION_ARG_FILENAME, &opt_render_node,
       "Specify DRM render node", "PATH" },

--- a/hw/display/virtio-vga.c
+++ b/hw/display/virtio-vga.c
@@ -161,7 +161,10 @@ static void virtio_vga_base_reset(DeviceState *dev)
     VirtIOVGABase *vvga = VIRTIO_VGA_BASE(dev);
 
     /* reset virtio-gpu */
-    virtio_gpu_reset(VIRTIO_DEVICE(vvga->vgpu));
+    DeviceClass *klass = DEVICE_GET_CLASS(vvga->vgpu);
+
+    if (klass->reset)
+        klass->reset(vvga->vgpu);
 
     /* reset vga */
     vga_common_reset(&vvga->vga);


### PR DESCRIPTION
Hello Marc-André, 

trying out the code I saw two problems that I was able to fix: 

vhost-user-gpu parsed the socket name as an integer and failed therefore, and virtio-vga hardcoded the call to the virtio-gpu-device reset method instead of routing to the device that was actually used. The two patches in the pull request fix this. 

(I still have a problem actually running vhost-user-gpu though, there are some problems with the memory maps, cf:  https://gitlab.freedesktop.org/virgl/virglrenderer/issues/73#note_99465) 

Best, 
Gert 